### PR TITLE
Set std library dependency behind a feature

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -8,6 +8,10 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/wdanilo/eval-macro"
 edition = { workspace = true }
 
+[features]
+default = ["std"]
+std = []
+
 [lib]
 
 [dependencies]

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -733,6 +733,7 @@
 //!
 //! [inline_dependency_injection]: ...
 //! [space_aware_interpolation]: ...
+#![cfg_attr(not(feature = "std"), no_std)]
 
 extern crate self as crabtime;
 pub use crabtime_internal::*;
@@ -773,7 +774,7 @@ macro_rules! quote {
 
 /// Most of the tests are included in the documentation above. These tests cover corner cases to
 /// ensure that the macro works as expected.
-#[cfg(test)]
+#[cfg(all(test, feature = "std"))]
 mod tests {
     #[test]
     fn empty_def_compilation() {


### PR DESCRIPTION
Hi!

I seen that this library can be quite useful, but I'm trying to use it a no_std context, for which the main library needs to be marked as no_std. This PR adds such attribute to the library.

I'm not seeing any reason today for completely removing the std, or even, the core dependency (maybe just for keeping the tests there?). However, since I'm not aware of future work on this library, I preferred, for the purposes of this PR, to add the "std" feature, enabled by default, that will make the crate depend on the std library.

Let me know if you see any concerns on this approach!