### PR TITLE
Allow code to compile on stable

### DIFF
--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -340,6 +340,7 @@ impl Paths {
         self
     }
 
+    #[cfg(nightly)]
     fn get_call_site_rel() -> PathBuf {
         // Sometimes `proc_macro::Span::call_site()` returns a relative path, sometimes an absolute
         // one. In the latter case, we need to discover the relative part from the project root.


### PR DESCRIPTION
Make `get_call_site_rel` nightly only so code can compile on stable.