### PR TITLE
Fixed dep versions not being quoted when using workspace deps

### DIFF
--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -562,11 +562,11 @@ impl CargoConfig {
             .and_then(toml::Value::as_str)
     }
 
-    fn get_package_version<'t>(table: &'t toml::Table, name: &str) -> Option<&'t str> {
+    fn get_package_version<'t>(table: &'t toml::Table, name: &str) -> Option<&'t toml::Value> {
         table.get("dependencies")
             .and_then(toml::Value::as_table)
             .and_then(|pkg_table| pkg_table.get(name))
-            .and_then(toml::Value::as_str)
+            .filter(|v| v.is_str())
     }
 
     fn print_lints(lints: &toml::Value) -> String {


### PR DESCRIPTION
Hi,

Raising this PR to fix an issue I've observed while trying to use workspace dependencies.

Given this workspace toml:

```toml
[workspace]
members = ["test-bin"]

[workspace.dependencies]
base64 = "0.22"
``` 

And this crate toml:

```toml
[package]
name = "test-bin"
version = "0.1.0"
edition = "2024"

[dependencies]
crabtime = { path = "../../crabtime/lib" }

[build-dependencies]
base64 = { workspace = true }
```

The generated toml for the eval project (in nightly) is missing the double quotes around the version of base64, and this is making the build to fail:

```toml
[workspace]
[package]
name     = "eval_project"
version  = "1.0.0"
edition  = "2024"
resolver = "3"

[dependencies]
base64 = 0.22

[lints.rust]


[lints.clippy]
```

This does not happen while using non-workspace dependencies, because, in this case, [here](https://github.com/wdanilo/crabtime/blob/75f39d60ffc513edd0eb9047abb71060f7566686/macro/src/lib.rs#L591), the `to_string` function is being called over a toml::Value value, which properly serializes the version using double quotes. For the case of [workspaces](https://github.com/wdanilo/crabtime/blob/75f39d60ffc513edd0eb9047abb71060f7566686/macro/src/lib.rs#L569), the `to_string` is just taking the version string as it is, without any quoting.