### PR TITLE
fix: swap Span::source_file -> Span::file

### DIFF
--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -376,7 +376,7 @@ impl Paths {
     fn get_call_site_rel() -> PathBuf {
         // Sometimes `proc_macro::Span::call_site()` returns a relative path, sometimes an absolute
         // one. In the latter case, we need to discover the relative part from the project root.
-        let mut call_site_path = proc_macro::Span::call_site().source_file().path();
+        let mut call_site_path: std::path::PathBuf = proc_macro::Span::call_site().file().into();
         call_site_path.set_extension("");
         if call_site_path.is_relative() {
             return call_site_path.to_path_buf();


### PR DESCRIPTION
Simple PR to adjust the method's name. It was previously named `source_file`, this changes starting in Rust 1.88.0 a.k.a current nightly. Since this method is only used in a nightly-feature-gated function, I didn't bother to feature-gate it further behind its implementation's feature (`proc_macro_span_file`)

## Related issues/PRs
- rust-lang/rust#54725
- rust-lang/rust#139903
- rust-lang/rust#140514